### PR TITLE
Support automatic dark/light mode

### DIFF
--- a/application/forms/Config/GeneralConfigForm.php
+++ b/application/forms/Config/GeneralConfigForm.php
@@ -149,19 +149,6 @@ class GeneralConfigForm extends ConfigForm
         );
         $this->addElement(
             'select',
-            'grafana_theme',
-            array(
-                'label' => $this->translate('Grafana theme'),
-                'value' => 'light',
-                'multiOptions' => array(
-                    'light' => $this->translate('Light'),
-                    'dark' => $this->translate('Dark'),
-                ),
-                'description' => $this->translate('Grafana theme that will be used.')
-            )
-        );
-        $this->addElement(
-            'select',
             'grafana_datasource',
             array(
                 'label' => $this->translate('Datasource Type'),

--- a/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
+++ b/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
@@ -34,7 +34,7 @@ trait IcingaDbGrapher
     protected $auth;
     protected $authentication;
     protected $grafanaHost = null;
-    protected $grafanaTheme = 'light';
+    protected $grafanaTheme = null;
     protected $protocol = "http";
     protected $usePublic = "no";
     protected $publicHost = null;
@@ -121,7 +121,7 @@ trait IcingaDbGrapher
             $this->defaultDashboardPanelId
         );
         $this->defaultOrgId = $this->config->get('defaultorgid', $this->defaultOrgId);
-        $this->grafanaTheme = $this->config->get('theme', $this->grafanaTheme);
+        $this->grafanaTheme = $this->getUserThemeMode();
         $this->height = $this->config->get('height', $this->height);
         $this->width = $this->config->get('width', $this->width);
 
@@ -784,5 +784,27 @@ trait IcingaDbGrapher
         $htmlForObject->add($menu);
         $htmlForObject->add($return_html);
         return $htmlForObject;
+    }
+
+    /**
+     * getUserThemeMode returns the users configured Theme Mode.
+     * Since we cannot handle the 'system' setting (it's client-side),
+     * we default to 'dark'.
+     * @return string
+     */
+    private function getUserThemeMode(): string
+    {
+        $mode = 'dark';
+
+        if ($user = Auth::getInstance()->getUser()) {
+                $mode = $user->getPreferences()->getValue('icingaweb', 'theme_mode', $mode);
+        }
+
+        // Could be system, which we cannot handle since it's browser-side
+        if (!in_array($mode, ['dark', 'light'])) {
+            $mode = 'dark';
+        }
+
+        return $mode;
     }
 }


### PR DESCRIPTION
There are some limitations, since we cannot handle
the client-side 'system' mode. But users' dark/light config
will now be used.

Fixes #5 