### PR TITLE
Encode custom variable that contain special characters

### DIFF
--- a/application/controllers/IcingadbimgController.php
+++ b/application/controllers/IcingadbimgController.php
@@ -193,7 +193,7 @@ class IcingadbimgController extends IcingadbGrafanaController
                 $this->customVars = str_replace($search, $replace, $this->customVars);
             }
 
-            // urlencodee values
+            // urlencode values
             $customVars = "";
             foreach (preg_split('/\&/', $this->customVars, -1, PREG_SPLIT_NO_EMPTY) as $param) {
                 $arr = explode("=", $param);

--- a/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
+++ b/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
@@ -437,7 +437,7 @@ trait IcingaDbGrapher
                 if ($this->dataSource === "graphite") {
                     $arr[1] = Util::graphiteReplace($arr[1]);
                 }
-                $customVars .= '&' . $arr[0] . '=' . rawurlencode($arr[1]);
+                $customVars .= '&' . $arr[0] . '=' . rawurlencode(implode('=', array_slice($arr, 1)));
             }
             $this->customVars = $customVars;
         }


### PR DESCRIPTION
This should fix custom variables with special characters not being encoded.

See upstream repo: https://github.com/Mikesch-mp/icingaweb2-module-grafana/issues/238 