### PR TITLE
Rework link to Grafana

### DIFF
--- a/application/forms/Config/GeneralConfigForm.php
+++ b/application/forms/Config/GeneralConfigForm.php
@@ -271,22 +271,8 @@ class GeneralConfigForm extends ConfigForm
                     'description' => $this->translate('The default graph width in pixels.')
                 ]
             );
-            $this->addElement(
-                'select',
-                'grafana_enableLink',
-                [
-                    'label' => $this->translate('Enable link'),
-                    'value' => 'no',
-                    'multiOptions' => [
-                        'yes' => $this->translate('Yes'),
-                        'no' => $this->translate('No'),
-                    ],
-                    'description' => $this->translate('Image is an link to the dashboard on the Grafana server.'),
-                    'class' => 'autosubmit'
-                ]
-            );
         }
-        if (isset($formData['grafana_enableLink']) && ( $formData['grafana_enableLink'] === 'yes') && ( $formData['grafana_accessmode'] != 'iframe' )) {
+        if (( $formData['grafana_accessmode'] != 'iframe' )) {
             $this->addElement(
                 'select',
                 'grafana_usepublic',

--- a/configuration.php
+++ b/configuration.php
@@ -9,7 +9,6 @@ $this->providePermission('grafana/graphconfig', $this->translate('Allow to confi
 $this->providePermission('grafana/graph', $this->translate('Allow to view graphs in dashboards.'));
 $this->providePermission('grafana/debug', $this->translate('Allow to see module debug information.'));
 $this->providePermission('grafana/showall', $this->translate('Allow access to see all graphs of a host.'));
-$this->providePermission('grafana/enablelink', $this->translate('Allow to follow links to Grafana.'));
 
 $this->provideConfigTab('config', [
     'title' => 'Configuration',

--- a/doc/03-module-configuration.md
+++ b/doc/03-module-configuration.md
@@ -35,7 +35,6 @@ height = "280"
 width = "640"
 timerange = "3h"
 timerangeAll = "1M/M"
-enableLink = "yes"
 defaultorgid = "1"
 defaultdashboard = "icinga2-default"
 defaultdashboardpanelid = "1"
@@ -66,7 +65,6 @@ ssl_verifyhost = "0"
 |width                  | **Optional.** Global graph width in pixel. Defaults to `640`.|
 |timerange              | **Optional.** Global time range for graphs. Defaults to `6h`.|
 |timerangeAll           | **Optional.** Time range for all graphs feature. Defaults to `Previous week`.|
-|enableLink             | **Optional.** Enable/disable graph with a rendered URL to the Grafana dashboard. Defaults to `yes`.|
 |datasource             | **Required for Grafana 4.x only.** Type of the Grafana datasource (`influxdb`, `graphite` or `pnp`). Defaults to `influxdb`.|
 |defaultdashboard       | **Required.** Name of the default dashboard which will be shown for unconfigured graphs. Set to `none` to hide the module output. Defaults to `icinga2-default`.|
 |defaultdashboarduid    | **Required for Grafana 5** The UID of the default dashboard for **Grafana 5**.
@@ -117,9 +115,6 @@ This option can be overwritten by a graph configuration.
 
 ### timerangeAll
 Time range for all graphs feature. Defaults to `Previous week`
-
-### enableLink
-Enable or disable the graphs as a link to the Grafana Server.
 
 ### datasource
 The datasource that Grafana server uses. Can be InfluxDB, Graphite.

--- a/public/css/module.less
+++ b/public/css/module.less
@@ -52,6 +52,12 @@
   padding: 0;
 }
 
+/* Icon to external pages like Grafana */
+.external-link {
+  margin: 0 0.33em;
+  font-size: 0.77em;
+}
+
 /* NAVIGATION */
 .grafana-menu-navigation {
   list-style: none;


### PR DESCRIPTION
This PR reworks the 'link to Grafana' behavior. 

- Remove configuration option and permission
- Always adds an 'external link' Icon with the link to Grafana (_blank)

Fixes #24 