### PR TITLE
Replace debug configuration option with URL parameter

### DIFF
--- a/application/forms/Config/GeneralConfigForm.php
+++ b/application/forms/Config/GeneralConfigForm.php
@@ -312,14 +312,5 @@ class GeneralConfigForm extends ConfigForm
                 ]
             );
         }
-        $this->addElement(
-            'checkbox',
-            'grafana_debug',
-            [
-                'value' => false,
-                'label' => $this->translate('Show debug'),
-                'description' => $this->translate('Show debugging information.'),
-            ]
-        );
     }
 }

--- a/configuration.php
+++ b/configuration.php
@@ -7,7 +7,7 @@ $auth = Auth::getInstance();
 
 $this->providePermission('grafana/graphconfig', $this->translate('Allow to configure graphs.'));
 $this->providePermission('grafana/graph', $this->translate('Allow to view graphs in dashboards.'));
-$this->providePermission('grafana/debug', $this->translate('Allow to see module debug information.'));
+$this->providePermission('grafana/debug', $this->translate('Allow to see debug information for graphs.'));
 $this->providePermission('grafana/showall', $this->translate('Allow access to see all graphs of a host.'));
 
 $this->provideConfigTab('config', [

--- a/doc/01-about.md
+++ b/doc/01-about.md
@@ -11,6 +11,15 @@ Add Grafana graphs into Icinga Web 2 to display performance metrics.
 
 To add a graph to your dashboard click on the small clock left of the timerange menu of a graph.
 
+## Permissions
+
+The module provides the following permissions:
+
+* `grafana/graphconfig`, Allow to configure graphs.
+* `grafana/graph`, Allow to view graphs in dashboards.
+* `grafana/showall`, Allow access to see all graphs of a host.
+* `grafana/debug` Allow to see debug information for graphs (can be accessed via the URL parameter `&grafanaDebug`).
+
 ## Show all graphs
 
 To see all graphs on one page, click on the `Show all graphs` link in a host object view.

--- a/doc/03-module-configuration.md
+++ b/doc/03-module-configuration.md
@@ -36,7 +36,6 @@ usepublic = "no"
 publichost = "otherhost:3000"
 publicprotocol = "http"
 custvardisable = "idontwanttoseeagraph"
-debug = "0"
 ssl_verifypeer = "0"
 ssl_verifyhost = "0"
 ```
@@ -69,7 +68,6 @@ ssl_verifyhost = "0"
 |publicprotocol         | **Optional** Use a different protocol for the graph links.|
 |custvardisable         | **Optional** Custom variable (vars.idontwanttoseeagraph for example) that will disable graphs. Defaults to `grafana_graph_disable`.|
 |custvarconfig          | **Optional** Custom variable (vars.usegraphconfig for example) that will be used as config name. Defaults to `grafana_graph_config`.|
-|debug                  | **Optional.** Enables the debug information under the graph if the user has permission to see them. Defaults to `disabled`.|
 |ssl_verifypeer         | **Proxy mode only** **Optional.** Verify the peer's SSL certificate. Defaults to `false`.|
 |ssl_verifyhost         | **Proxy mode only** **Optional.** Verify the certificate's name against host. Defaults to `false`.|
 
@@ -196,6 +194,3 @@ This will overwrite the search order and force the module to use the graph confi
 For example you have `vars.grafana_graph_config = "check_my_tesla"` in your service configuration, the module will look for
 an [graph configuration](04-graph-configuration.md) that is named `check_my_tesla` and use this to render/show the performance graph.
 If there is no such a configuration, the `default-template` will be used.
-
-### debug
-Show debug information if user has permission to see them. Defaults to `false`.

--- a/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
+++ b/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
@@ -67,7 +67,6 @@ trait IcingaDbGrapher
     protected $custvarconfig = "grafana_graph_config";
     protected $repeatable = "no";
     protected $numberMetrics = "1";
-    protected $debug = false;
     protected $SSLVerifyPeer = false;
     protected $SSLVerifyHost = "0";
     protected $cacheTime = 300;
@@ -153,10 +152,6 @@ trait IcingaDbGrapher
          */
         $this->custvarconfig = ($this->config->get('custvarconfig', $this->custvarconfig));
 
-        /**
-         * Show some debug information?
-         */
-        $this->debug = ($this->config->get('debug', $this->debug));
         /**
          * Verify the certificate's name against host
          */
@@ -503,7 +498,7 @@ trait IcingaDbGrapher
         }
 
         // Add a data table with runtime information and configuration for debugging purposes
-        if ($this->debug && $this->permission->hasPermission('grafana/debug') && $report === false) {
+        if (Url::fromRequest()->hasParam('grafanaDebug') && $this->permission->hasPermission('grafana/debug') && $report === false) {
             $returnHtml->addHtml(HtmlElement::create('h2', null, 'Performance Graph Debug'));
             $returnHtml->add($this->createDebugTable());
         }


### PR DESCRIPTION
- Users can have access to the debug information without having access to the module's config to enable it
- No need to fiddle in the config to enable/disable debug info

Fixes #30 