### PR TITLE
[Feat] support splitting single graph into multiple graphs via imagefilters

### DIFF
--- a/application/controllers/IcingadbimgController.php
+++ b/application/controllers/IcingadbimgController.php
@@ -52,6 +52,7 @@ class IcingadbimgController extends IcingadbGrafanaController
     protected $orgId;
     protected $detect;
     protected $timezone;
+    protected $imagefilter;
 
     /**
      * Mainly loading defaults and the configuration.
@@ -126,6 +127,9 @@ class IcingadbimgController extends IcingadbGrafanaController
         $this->dataSource = $this->myConfig->get('datasource', $this->dataSource);
         $this->shadows = $this->myConfig->get('shadows', $this->shadows);
         $this->custvarconfig = ($this->myConfig->get('custvarconfig', $this->custvarconfig));
+
+        $this->imagefilter = $this->hasParam('imagefilter') ? urldecode($this->getParam('imagefilter')) : "";
+
         $this->SSLVerifyHost = ($this->myConfig->get('ssl_verifyhost', $this->SSLVerifyHost));
         $this->SSLVerifyPeer = ($this->myConfig->get('ssl_verifypeer', $this->SSLVerifyPeer));
 
@@ -289,7 +293,7 @@ class IcingadbimgController extends IcingadbGrafanaController
 
         $pngUrl = sprintf(
             '%s://%s/render/d-solo/%s/%s?var-hostname=%s&var-service=%s&var-command=%s%s&panelId=%s&orgId=%s&hideLogo=true'
-            . '&width=%s&height=%s&theme=%s&from=%s&to=%s&timezone=%s',
+            . '&width=%s&height=%s&theme=%s&from=%s&to=%s&timezone=%s%s',
             $this->protocol,
             $this->grafanaHost,
             $this->dashboarduid,
@@ -305,7 +309,8 @@ class IcingadbimgController extends IcingadbGrafanaController
             $this->grafanaTheme,
             urlencode($this->timerange),
             urlencode($this->timerangeto),
-            urlencode($this->timezone)
+            urlencode($this->timezone),
+            $this->imagefilter
         );
 
         // fetch image with curl

--- a/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
+++ b/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
@@ -247,7 +247,7 @@ trait IcingaDbGrapher
      * @return bool
      * @throws \Icinga\Exception\ProgrammingError
      */
-    private function getMyPreviewHtml($serviceName, $hostName, HtmlDocument $previewHtml): bool
+    private function getMyPreviewHtml($serviceName, $hostName, HtmlDocument $previewHtml, $imageFilter = ""): bool
     {
         $imgClass = $this->shadows ? "grafana-img grafana-img-shadows" : "grafana-img";
 
@@ -261,7 +261,8 @@ trait IcingaDbGrapher
                     'panelid' => $this->panelId,
                     'timerange' => urlencode($this->timerange),
                     'timerangeto' => urlencode($this->timerangeto),
-                    'cachetime' => $this->cacheTime
+                    'cachetime' => $this->cacheTime,
+                    'imagefilter' => urlencode($imageFilter)
                     ]
                 );
             } else {
@@ -272,7 +273,8 @@ trait IcingaDbGrapher
                     'panelid' => $this->panelId,
                     'timerange' => urlencode($this->timerange),
                     'timerangeto' => urlencode($this->timerangeto),
-                    'cachetime' => $this->cacheTime
+                    'cachetime' => $this->cacheTime,
+                    'imagefilter' => urlencode($imageFilter)
                     ]
                 );
             }
@@ -476,27 +478,42 @@ trait IcingaDbGrapher
             $html = new HtmlDocument();
             $this->panelId = $panelid;
 
-            // The image value will be returned as reference
-            $previewHtml = new HtmlDocument();
-            $res = $this->getMyPreviewHtml($serviceName, $hostName, $previewHtml);
-
-            if ($res) {
-                // Add Link to Panel if the user has the permission
-                if ($this->permission->hasPermission('grafana/showlink')) {
-                    $linkUrl = $url;
-                    if ($this->dashboardLink) {
-                        $linkUrl = preg_replace('/(viewPanel=)[^&]+/', '', $linkUrl);
-                    } else {
-                        $linkUrl = preg_replace('/(viewPanel=)[^&]+/', '${1}' . $panelid, $linkUrl);
-                    }
-                    $textLink = new Link('View in Grafana', $linkUrl, ['target' => '_blank', 'class' => 'external-link']);
-                    $html->add($textLink);
-                    $iconLink = new Link(new Icon('arrow-up-right-from-square', ['title' => 'View in Grafana']), $linkUrl, ['target' => '_blank', 'class' => 'external-link']);
-                    $html->add($iconLink);
-                }
-
-                $html->addHtml($previewHtml);
+            $flattened_vars = $object->vars;
+            // The $object->vars array is flattened, we unflatten the subarray grafanaimagefiltersarray here:
+            $i = 0;
+            $info = [];
+            while (isset($flattened_vars['grafanaimagefiltersarray[' . $i . ']'])) {
+                $info[$i] = $flattened_vars['grafanaimagefiltersarray[' . $i . ']'];
+                $i++;
             }
+
+            $i = 0;
+            do {
+                $value = $info ? $info[$i] : "";
+
+                // The image value will be returned as reference
+                $previewHtml = new HtmlDocument();
+                $res = $this->getMyPreviewHtml($serviceName, $hostName, $previewHtml, $value);
+
+                if ($res) {
+                    // Add Link to Panel if the user has the permission
+                    if ($this->permission->hasPermission('grafana/showlink')) {
+                        $linkUrl = $url;
+                        if ($this->dashboardLink) {
+                            $linkUrl = preg_replace('/(viewPanel=)[^&]+/', '', $linkUrl);
+                        } else {
+                            $linkUrl = preg_replace('/(viewPanel=)[^&]+/', '${1}' . $panelid, $linkUrl);
+                        }
+                        $textLink = new Link('View in Grafana', $linkUrl, ['target' => '_blank', 'class' => 'external-link']);
+                        $html->add($textLink);
+                        $iconLink = new Link(new Icon('arrow-up-right-from-square', ['title' => 'View in Grafana']), $linkUrl, ['target' => '_blank', 'class' => 'external-link']);
+                        $html->add($iconLink);
+                    }
+
+                    $html->addHtml($previewHtml);
+                }
+                $i++;
+            } while ($i < count($info));
 
             $returnHtml->add($html);
         }


### PR DESCRIPTION
# Summary
This change allows the Grafana graph to be split into multiple separate graphs.

This is useful, if multiple values are plotted into the same graph and their value ranges are quite different. So small value changes are much more visible.

Here is an example with and without this change:

### Without change
![Bildschirmfoto vom 2024-12-19 11-54-28](https://github.com/user-attachments/assets/d0a50288-66ab-433e-ae17-ede87d62ef83)


### With change
![Bildschirmfoto vom 2024-12-19 11-53-51 (Kopie)](https://github.com/user-attachments/assets/b179b5f9-58a5-4f8c-ac91-5c2227c5de5e)
![Bildschirmfoto vom 2024-12-19 11-53-51 (Kopie 2)](https://github.com/user-attachments/assets/9a374343-304d-4133-8100-2257a664b958)



## Configuration
The values, which should be separated into an additional graph are specified via the `Custom variable` `grafanaimagefiltersarray`.

Each entry inside the `grafanaimagefiltersarray` defines a new graph and its value specifies which value should be omitted via a `var-metricfilter`. See the following example:
![Bildschirmfoto vom 2024-12-19 11-54-49](https://github.com/user-attachments/assets/503f876e-2810-492d-a3c1-6eca3e801052)




