### PR TITLE
Change type of dashboard variables from constant to custom

### DIFF
--- a/dashboards/graphite/icinga2-default.json
+++ b/dashboards/graphite/icinga2-default.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""
@@ -213,7 +213,7 @@
           }
         ],
         "query": "${VAR_HOSTNAME}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -230,7 +230,7 @@
           }
         ],
         "query": "${VAR_SERVICE}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -247,7 +247,7 @@
           }
         ],
         "query": "${VAR_COMMAND}",
-        "type": "constant"
+        "type": "custom"
       }
     ]
   },

--- a/dashboards/graphite/itl/disk.json
+++ b/dashboards/graphite/itl/disk.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""
@@ -210,7 +210,7 @@
           }
         ],
         "query": "${VAR_HOSTNAME}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -227,7 +227,7 @@
           }
         ],
         "query": "${VAR_SERVICE}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -244,7 +244,7 @@
           }
         ],
         "query": "${VAR_COMMAND}",
-        "type": "constant"
+        "type": "custom"
       }
     ]
   },

--- a/dashboards/graphite/itl/hostalive.json
+++ b/dashboards/graphite/itl/hostalive.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""
@@ -217,7 +217,7 @@
           }
         ],
         "query": "${VAR_HOSTNAME}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -234,7 +234,7 @@
           }
         ],
         "query": "${VAR_SERVICE}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -251,7 +251,7 @@
           }
         ],
         "query": "${VAR_COMMAND}",
-        "type": "constant"
+        "type": "custom"
       }
     ]
   },

--- a/dashboards/graphite/itl/hostalive4.json
+++ b/dashboards/graphite/itl/hostalive4.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""
@@ -217,7 +217,7 @@
           }
         ],
         "query": "${VAR_HOSTNAME}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -234,7 +234,7 @@
           }
         ],
         "query": "${VAR_SERVICE}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -251,7 +251,7 @@
           }
         ],
         "query": "${VAR_COMMAND}",
-        "type": "constant"
+        "type": "custom"
       }
     ]
   },

--- a/dashboards/graphite/itl/hostalive6.json
+++ b/dashboards/graphite/itl/hostalive6.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""
@@ -218,7 +218,7 @@
           }
         ],
         "query": "${VAR_HOSTNAME}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -235,7 +235,7 @@
           }
         ],
         "query": "${VAR_SERVICE}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -252,7 +252,7 @@
           }
         ],
         "query": "${VAR_COMMAND}",
-        "type": "constant"
+        "type": "custom"
       }
     ]
   },

--- a/dashboards/graphite/itl/http.json
+++ b/dashboards/graphite/itl/http.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""
@@ -216,7 +216,7 @@
           }
         ],
         "query": "${VAR_HOSTNAME}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -233,7 +233,7 @@
           }
         ],
         "query": "${VAR_SERVICE}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -250,7 +250,7 @@
           }
         ],
         "query": "${VAR_COMMAND}",
-        "type": "constant"
+        "type": "custom"
       }
     ]
   },

--- a/dashboards/graphite/itl/ido.json
+++ b/dashboards/graphite/itl/ido.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""
@@ -222,7 +222,7 @@
           }
         ],
         "query": "${VAR_HOSTNAME}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -239,7 +239,7 @@
           }
         ],
         "query": "${VAR_SERVICE}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -256,7 +256,7 @@
           }
         ],
         "query": "${VAR_COMMAND}",
-        "type": "constant"
+        "type": "custom"
       }
     ]
   },

--- a/dashboards/graphite/itl/load.json
+++ b/dashboards/graphite/itl/load.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""
@@ -210,7 +210,7 @@
           }
         ],
         "query": "${VAR_HOSTNAME}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -227,7 +227,7 @@
           }
         ],
         "query": "${VAR_SERVICE}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -244,7 +244,7 @@
           }
         ],
         "query": "${VAR_COMMAND}",
-        "type": "constant"
+        "type": "custom"
       }
     ]
   },

--- a/dashboards/graphite/itl/nscp-local-cpu.json
+++ b/dashboards/graphite/itl/nscp-local-cpu.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""
@@ -178,7 +178,7 @@
           }
         ],
         "query": "${VAR_HOSTNAME}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -195,7 +195,7 @@
           }
         ],
         "query": "${VAR_SERVICE}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -212,7 +212,7 @@
           }
         ],
         "query": "${VAR_COMMAND}",
-        "type": "constant"
+        "type": "custom"
       }
     ]
   },

--- a/dashboards/graphite/itl/nscp-local-disk.json
+++ b/dashboards/graphite/itl/nscp-local-disk.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""
@@ -216,7 +216,7 @@
           }
         ],
         "query": "${VAR_HOSTNAME}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -233,7 +233,7 @@
           }
         ],
         "query": "${VAR_SERVICE}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -250,7 +250,7 @@
           }
         ],
         "query": "${VAR_COMMAND}",
-        "type": "constant"
+        "type": "custom"
       }
     ]
   },

--- a/dashboards/graphite/itl/nscp-local-memory.json
+++ b/dashboards/graphite/itl/nscp-local-memory.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""
@@ -216,7 +216,7 @@
           }
         ],
         "query": "${VAR_HOSTNAME}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -233,7 +233,7 @@
           }
         ],
         "query": "${VAR_SERVICE}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -250,7 +250,7 @@
           }
         ],
         "query": "${VAR_COMMAND}",
-        "type": "constant"
+        "type": "custom"
       }
     ]
   },

--- a/dashboards/graphite/itl/nscp-local-pagefile.json
+++ b/dashboards/graphite/itl/nscp-local-pagefile.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""
@@ -216,7 +216,7 @@
           }
         ],
         "query": "${VAR_HOSTNAME}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -233,7 +233,7 @@
           }
         ],
         "query": "${VAR_SERVICE}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -250,7 +250,7 @@
           }
         ],
         "query": "${VAR_COMMAND}",
-        "type": "constant"
+        "type": "custom"
       }
     ]
   },

--- a/dashboards/graphite/itl/ntp_time.json
+++ b/dashboards/graphite/itl/ntp_time.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""
@@ -209,7 +209,7 @@
           }
         ],
         "query": "${VAR_HOSTNAME}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -226,7 +226,7 @@
           }
         ],
         "query": "${VAR_SERVICE}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -243,7 +243,7 @@
           }
         ],
         "query": "${VAR_COMMAND}",
-        "type": "constant"
+        "type": "custom"
       }
     ]
   },

--- a/dashboards/graphite/itl/ping.json
+++ b/dashboards/graphite/itl/ping.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""
@@ -218,7 +218,7 @@
           }
         ],
         "query": "${VAR_HOSTNAME}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -235,7 +235,7 @@
           }
         ],
         "query": "${VAR_SERVICE}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -252,7 +252,7 @@
           }
         ],
         "query": "${VAR_COMMAND}",
-        "type": "constant"
+        "type": "custom"
       }
     ]
   },

--- a/dashboards/graphite/itl/ping4.json
+++ b/dashboards/graphite/itl/ping4.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""
@@ -217,7 +217,7 @@
           }
         ],
         "query": "${VAR_HOSTNAME}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -234,7 +234,7 @@
           }
         ],
         "query": "${VAR_SERVICE}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -251,7 +251,7 @@
           }
         ],
         "query": "${VAR_COMMAND}",
-        "type": "constant"
+        "type": "custom"
       }
     ]
   },

--- a/dashboards/graphite/itl/ping6.json
+++ b/dashboards/graphite/itl/ping6.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""
@@ -217,7 +217,7 @@
           }
         ],
         "query": "${VAR_HOSTNAME}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -234,7 +234,7 @@
           }
         ],
         "query": "${VAR_SERVICE}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -251,7 +251,7 @@
           }
         ],
         "query": "${VAR_COMMAND}",
-        "type": "constant"
+        "type": "custom"
       }
     ]
   },

--- a/dashboards/graphite/itl/ssh.json
+++ b/dashboards/graphite/itl/ssh.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""
@@ -209,7 +209,7 @@
           }
         ],
         "query": "${VAR_HOSTNAME}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -226,7 +226,7 @@
           }
         ],
         "query": "${VAR_SERVICE}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -243,7 +243,7 @@
           }
         ],
         "query": "${VAR_COMMAND}",
-        "type": "constant"
+        "type": "custom"
       }
     ]
   },

--- a/dashboards/graphite/itl/swap.json
+++ b/dashboards/graphite/itl/swap.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""
@@ -209,7 +209,7 @@
           }
         ],
         "query": "${VAR_HOSTNAME}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -226,7 +226,7 @@
           }
         ],
         "query": "${VAR_SERVICE}",
-        "type": "constant"
+        "type": "custom"
       },
       {
         "current": {
@@ -243,7 +243,7 @@
           }
         ],
         "query": "${VAR_COMMAND}",
-        "type": "constant"
+        "type": "custom"
       }
     ]
   },

--- a/dashboards/influxdb/auto-repeat-disk.json
+++ b/dashboards/influxdb/auto-repeat-disk.json
@@ -10,14 +10,14 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "",
       "description": ""

--- a/dashboards/influxdb/icinga2-default.json
+++ b/dashboards/influxdb/icinga2-default.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""

--- a/dashboards/influxdb/itl/disk.json
+++ b/dashboards/influxdb/itl/disk.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""

--- a/dashboards/influxdb/itl/hostalive.json
+++ b/dashboards/influxdb/itl/hostalive.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""

--- a/dashboards/influxdb/itl/hostalive4.json
+++ b/dashboards/influxdb/itl/hostalive4.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""

--- a/dashboards/influxdb/itl/hostalive6.json
+++ b/dashboards/influxdb/itl/hostalive6.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""

--- a/dashboards/influxdb/itl/http.json
+++ b/dashboards/influxdb/itl/http.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""

--- a/dashboards/influxdb/itl/ido.json
+++ b/dashboards/influxdb/itl/ido.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "",
       "description": ""

--- a/dashboards/influxdb/itl/load.json
+++ b/dashboards/influxdb/itl/load.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""

--- a/dashboards/influxdb/itl/nscp-local-cpu.json
+++ b/dashboards/influxdb/itl/nscp-local-cpu.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""

--- a/dashboards/influxdb/itl/nscp-local-disk-free.json
+++ b/dashboards/influxdb/itl/nscp-local-disk-free.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""

--- a/dashboards/influxdb/itl/nscp-local-memory.json
+++ b/dashboards/influxdb/itl/nscp-local-memory.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""

--- a/dashboards/influxdb/itl/nscp-local-pagefile.json
+++ b/dashboards/influxdb/itl/nscp-local-pagefile.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""

--- a/dashboards/influxdb/itl/ntp_time.json
+++ b/dashboards/influxdb/itl/ntp_time.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""

--- a/dashboards/influxdb/itl/ping.json
+++ b/dashboards/influxdb/itl/ping.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""

--- a/dashboards/influxdb/itl/ping4.json
+++ b/dashboards/influxdb/itl/ping4.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""

--- a/dashboards/influxdb/itl/ping6.json
+++ b/dashboards/influxdb/itl/ping6.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""

--- a/dashboards/influxdb/itl/ssh.json
+++ b/dashboards/influxdb/itl/ssh.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""

--- a/dashboards/influxdb/itl/swap.json
+++ b/dashboards/influxdb/itl/swap.json
@@ -10,21 +10,21 @@
     },
     {
       "name": "VAR_HOSTNAME",
-      "type": "constant",
+      "type": "custom",
       "label": "hostname",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_SERVICE",
-      "type": "constant",
+      "type": "custom",
       "label": "service",
       "value": "null",
       "description": ""
     },
     {
       "name": "VAR_COMMAND",
-      "type": "constant",
+      "type": "custom",
       "label": "command",
       "value": "null",
       "description": ""


### PR DESCRIPTION
With Grafana 11.3 most of the dashboards broke, due to Grafana enforcing that constants are
actually constant ( o.O ) (ref: https://github.com/grafana/grafana/issues/90635 ).

Since this was a breaking change but actually a bugfix, the dashboards in here should be
updated.

This PR changes the `type` of all dashboard variabels from `constant` to `custom`.
It should not change anything really on Grafana < 11.3 and in general just restore the
functionality on >= 11.3