### PR TITLE
Reintroduce configuration option for theme

### DIFF
--- a/application/controllers/IcingadbimgController.php
+++ b/application/controllers/IcingadbimgController.php
@@ -100,7 +100,7 @@ class IcingadbimgController extends IcingadbGrafanaController
         );
 
         $this->defaultOrgId = $this->myConfig->get('defaultorgid', $this->defaultOrgId);
-        $this->grafanaTheme = Util::getUserThemeMode(Auth::getInstance()->getUser());
+        $this->grafanaTheme = Util::getUserThemeMode(Auth::getInstance()->getUser(), $this->myConfig->get('theme', 'dark'));
         $this->height = $this->myConfig->get('height', $this->height);
         $this->width = $this->myConfig->get('width', $this->width);
         $this->proxyTimeout = $this->myConfig->get('proxytimeout', $this->proxyTimeout);

--- a/application/forms/Config/GeneralConfigForm.php
+++ b/application/forms/Config/GeneralConfigForm.php
@@ -161,6 +161,21 @@ class GeneralConfigForm extends ConfigForm
             ]
         );
 
+        // Default theme
+        $this->addElement(
+            'select',
+            'grafana_theme',
+            array(
+                'label' => $this->translate('Default theme for graphs'),
+                'value' => 'dark',
+                'multiOptions' => array(
+                    'light' => $this->translate('Light'),
+                    'dark' => $this->translate('Dark'),
+                ),
+                'description' => $this->translate("Default theme for graphs. Hint: the user's theme will take precedence")
+            )
+        );
+
         // Grafana datasource configuration
         $this->addElement(
             'select',

--- a/doc/03-module-configuration.md
+++ b/doc/03-module-configuration.md
@@ -70,6 +70,7 @@ Hint: to display debug information for graphs you can use the URL parameter `&gr
 |publicprotocol         | **Optional** Use a different protocol for the graph links.|
 |custvardisable         | **Optional** Custom variable (vars.idontwanttoseeagraph for example) that will disable graphs. Defaults to `grafana_graph_disable`.|
 |custvarconfig          | **Optional** Custom variable (vars.usegraphconfig for example) that will be used as config name. Defaults to `grafana_graph_config`.|
+|theme                  | **Optional.** Default theme for the graph (light or dark). Hint: the user's theme will take precedence. Defaults to `dark`.|
 |ssl_verifypeer         | **Proxy mode only** **Optional.** Verify the peer's SSL certificate. Defaults to `false`.|
 |ssl_verifyhost         | **Proxy mode only** **Optional.** Verify the certificate's name against host. Defaults to `false`.|
 

--- a/library/Grafana/Helpers/Util.php
+++ b/library/Grafana/Helpers/Util.php
@@ -16,14 +16,15 @@ class Util
     /**
      * getUserThemeMode returns the users configured Theme Mode.
      * Since we cannot handle the 'system' setting (it's client-side),
-     * we default to 'dark'.
+     * we default to the mode given. This is used to pass the default
+     * from the module's configuration.
      *
      * @param User $user
      * @return string
      */
-    public static function getUserThemeMode(User $user): string
+    public static function getUserThemeMode(User $user, string $defaultMode = 'dark'): string
     {
-        $mode = 'dark';
+        $mode = $defaultMode;
 
         if (isset($user)) {
             $mode = $user->getPreferences()->getValue('icingaweb', 'theme_mode', $mode);
@@ -31,7 +32,7 @@ class Util
 
         // Could be system, which we cannot handle since it's browser-side
         if (!in_array($mode, ['dark', 'light'])) {
-            $mode = 'dark';
+            $mode = $defaultMode;
         }
 
         return $mode;

--- a/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
+++ b/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
@@ -132,7 +132,7 @@ trait IcingaDbGrapher
         );
 
         $this->defaultOrgId = $this->config->get('defaultorgid', $this->defaultOrgId);
-        $this->grafanaTheme = Util::getUserThemeMode(Auth::getInstance()->getUser());
+        $this->grafanaTheme = Util::getUserThemeMode(Auth::getInstance()->getUser(), $this->config->get('theme', 'dark'));
         $this->height = $this->config->get('height', $this->height);
         $this->width = $this->config->get('width', $this->width);
 


### PR DESCRIPTION
A default theme option can be set, that will then be overridden if the user has set a theme explicitly

Fixes #55