### PR TITLE
Update GeneralConfigForm.php

### DIFF
--- a/application/forms/Config/GeneralConfigForm.php
+++ b/application/forms/Config/GeneralConfigForm.php
@@ -131,12 +131,12 @@ class GeneralConfigForm extends ConfigForm
             ]
         );
         $this->addElement(
-            'number',
+            'text',
             'grafana_defaultdashboardpanelid',
             [
                 'value' => '1',
-                'label' => $this->translate('Default panel ID'),
-                'description' => $this->translate('ID of the panel used in the default dashboard.'),
+                'label' => $this->translate('Default panel ID(s)'),
+                'description' => $this->translate('Comma separated IDs of the panels used in the default dashboard.'),
                 'required' => true,
             ]
         );


### PR DESCRIPTION
Change default dashboard id textbox from number to text to allow comma separated lists. The code already works to display multiple panels, but the config page doesn't allow non-numeric input.
Tested in production. I wanted to have both an influxdb graph and a loki log view as the default.