### PR TITLE
Feature: Config option that switches Grafana-Link destination

### DIFF
--- a/application/forms/Config/GeneralConfigForm.php
+++ b/application/forms/Config/GeneralConfigForm.php
@@ -161,6 +161,17 @@ class GeneralConfigForm extends ConfigForm
             ]
         );
 
+        // Grafana link to dashboard/panel configuration
+        $this->addElement(
+            'checkbox',
+            'grafana_dashboardlink',
+            [
+                'value' => false,
+                'label' => $this->translate('Link to dashboard'),
+                'description' => $this->translate('Link points to the dashboard instead of a single panel.'),
+            ]
+        );
+
         // Default theme
         $this->addElement(
             'select',

--- a/doc/03-module-configuration.md
+++ b/doc/03-module-configuration.md
@@ -126,7 +126,7 @@ The IDs of the panels used in the default dashboard. Defaults to `1`.
 Enable/Disable fancy shadows around the graph image.
 
 ### dashboardlink
-Controls whether the "view in grafana" link points to the whole dashboard or only to the panel (default). This is useful when only specific or single panels are shown in Icingaweb2 and the dashboard contains addiitonal panels.
+Controls whether the "view in grafana" link points to the whole dashboard or only to the panel (default). This is useful when only specific or single panels are shown in Icingaweb2 and the dashboard contains additional panels.
 
 ### accessmode
 Controls how the graphs are fetched/delivered for/to the users.

--- a/doc/03-module-configuration.md
+++ b/doc/03-module-configuration.md
@@ -38,6 +38,7 @@ publicprotocol = "http"
 custvardisable = "idontwanttoseeagraph"
 ssl_verifypeer = "0"
 ssl_verifyhost = "0"
+dashboardlink = "0"
 ```
 
 Hint: to display debug information for graphs you can use the URL parameter `&grafanaDebug`. This requires the `grafana/debug` permission.
@@ -57,6 +58,7 @@ Hint: to display debug information for graphs you can use the URL parameter `&gr
 |defaultdashboarduid    | **Required for Grafana 5** The UID of the default dashboard for **Grafana 5**.
 |defaultdashboardpanelid| **Required** IDs of the panels used in the default dashboard. Defaults to `1`.
 |shadows                | **Optional.** Show shadows around the graphs. ** Defaults to `false`.|
+|dashboardlink          | **Optional.** Link to the dashboard instead to a single panel. |
 |defaultorgid           | **Required.** Number of the default organization id where dashboards are located. Defaults to `1`.
 |accessmode             | **Optional.** Controls whether graphs are fetched with curl (`indirectproxy`) or in iframe ('iframe'). Iframe needs `auth.anonymous` enabled in Grafana. Defaults to `indirectproxy`.|
 |timeout                | **Proxy only** **Optional.** Timeout in seconds for proxy mode to fetch images. Defaults to `5`.|
@@ -122,6 +124,9 @@ The IDs of the panels used in the default dashboard. Defaults to `1`.
 
 ### shadows
 Enable/Disable fancy shadows around the graph image.
+
+### dashboardlink
+Controls whether the "view in grafana" link points to the whole dashboard or only to the panel (default). This is useful when only specific or single panels are shown in Icingaweb2 and the dashboard contains addiitonal panels.
 
 ### accessmode
 Controls how the graphs are fetched/delivered for/to the users.

--- a/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
+++ b/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
@@ -484,10 +484,9 @@ trait IcingaDbGrapher
                 // Add Link to Panel if the user has the permission
                 if ($this->permission->hasPermission('grafana/showlink')) {
                     $linkUrl = $url;
-                    if ( $this->dashboardLink ) {
+                    if ($this->dashboardLink) {
                         $linkUrl = preg_replace('/(viewPanel=)[^&]+/', '', $linkUrl);
-                    }
-                    else {
+                    } else {
                         $linkUrl = preg_replace('/(viewPanel=)[^&]+/', '${1}' . $panelid, $linkUrl);
                     }
                     $textLink = new Link('View in Grafana', $linkUrl, ['target' => '_blank', 'class' => 'external-link']);

--- a/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
+++ b/library/Grafana/ProvidedHook/Icingadb/IcingaDbGrapher.php
@@ -61,6 +61,7 @@ trait IcingaDbGrapher
     protected $defaultDashboardPanelId = "1";
     protected $defaultOrgId = "1";
     protected $shadows = false;
+    protected $dashboardLink = false;
     protected $dataSource = null;
     protected $accessMode = "proxy";
     protected $proxyTimeout = "5";
@@ -142,6 +143,7 @@ trait IcingaDbGrapher
         $this->timerange = $this->config->get('timerange', $this->timerange);
         $this->dataSource = $this->config->get('datasource', $this->dataSource);
         $this->shadows = $this->config->get('shadows', $this->shadows);
+        $this->dashboardLink = $this->config->get('dashboardlink', $this->dashboardLink);
         $this->custvardisable = ($this->config->get('custvardisable', $this->custvardisable));
         $this->custvarconfig = ($this->config->get('custvarconfig', $this->custvarconfig));
 
@@ -482,7 +484,12 @@ trait IcingaDbGrapher
                 // Add Link to Panel if the user has the permission
                 if ($this->permission->hasPermission('grafana/showlink')) {
                     $linkUrl = $url;
-                    $linkUrl = preg_replace('/(viewPanel=)[^&]+/', '${1}' . $panelid, $linkUrl);
+                    if ( $this->dashboardLink ) {
+                        $linkUrl = preg_replace('/(viewPanel=)[^&]+/', '', $linkUrl);
+                    }
+                    else {
+                        $linkUrl = preg_replace('/(viewPanel=)[^&]+/', '${1}' . $panelid, $linkUrl);
+                    }
                     $textLink = new Link('View in Grafana', $linkUrl, ['target' => '_blank', 'class' => 'external-link']);
                     $html->add($textLink);
                     $iconLink = new Link(new Icon('arrow-up-right-from-square', ['title' => 'View in Grafana']), $linkUrl, ['target' => '_blank', 'class' => 'external-link']);


### PR DESCRIPTION
Add a configuration option "Link to dashboard".

If set to 'on', the link "View in Grafana" points to the whole dashboard instead of a single panel. This is useful when only specific or single panels are shown in Icingaweb2 and the dashboard contains addiitonal panels.