### PR TITLE
Clarify removal of Grafana Image Renderer Plugin in Grafana 13

### DIFF
--- a/doc/02-installation.md
+++ b/doc/02-installation.md
@@ -14,7 +14,7 @@ to the latest version, please [read on here](05-update.md).
 
 The Grafana Image Renderer handles rendering panels and dashboards to PNGs using a headless browser (Chromium).
 
-**Note:** Grafana Image Renderer was deprecated in September 2025 and removed in Grafana 13.
+**Note:** The Grafana Image Renderer Plugin was deprecated in September 2025 and removed in Grafana 13. The image renderer now exists only as a service that you can deploy separately alongside Grafana.
 
 A data source as a backend for Grafana. Either:
 

--- a/doc/03-module-configuration.md
+++ b/doc/03-module-configuration.md
@@ -138,7 +138,7 @@ This will speed up the page load, but the image will take some seconds to show u
 Pro: Very fast page loading, very secure.
 Contra: Images take some seconds to show up.
 
-**Note:** Grafana Image Renderer was deprecated in September 2025 and removed in Grafana 13.
+**Note:** The Grafana Image Renderer Plugin was deprecated in September 2025 and removed in Grafana 13. The image renderer now exists only as a service that you can deploy separately alongside Grafana.
 
 #### iframe
 In iframe mode you have the full power of Grafana features like mouse over tool tip.


### PR DESCRIPTION
...as the Image Renderer Service is now "the way to go": https://grafana.com/whats-new/2026-04-14-grafana-image-renderer-plugin-support-removed/