### PR TITLE
Fix undefined variable $result in Util::graphiteReplace

### DIFF
--- a/library/Grafana/Helpers/Util.php
+++ b/library/Grafana/Helpers/Util.php
@@ -20,7 +20,7 @@ class Util
 
     public static function graphiteReplace(string $string = ''): string
     {
-        $string = preg_replace('/[^a-zA-Z0-9\*\-:]/', '_', $string);
+        $result = preg_replace('/[^a-zA-Z0-9\*\-:]/', '_', $string);
         // Fallback to original or empty string
         return $result !== null ? $result : $string;
     }


### PR DESCRIPTION
preg_replace assigned to $string while the return statement reads $result, which is never set. PHP 8 warns, Icinga Web turns that into an ErrorException, and the detail view shows it instead of a graph. Only reachable with datasource=graphite and an accessmode other than indirectproxy. Return value is unchanged.